### PR TITLE
Unexpected key 'database' found in params

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,8 +266,8 @@ const sqlString = require('sqlstring')
 
 
   // Merge configuration data with supplied arguments
-  const mergeConfig = ({secretArn,resourceArn,database},args) =>
-    Object.assign({secretArn,resourceArn,database},args)
+  const mergeConfig = (initialConfig,args) =>
+    Object.assign(initialConfig,args)
 
 
 


### PR DESCRIPTION
Whenever I use `mysql.rollbackTransaction({ transactionId })` the following error is thrown:

```
(node:233) UnhandledPromiseRejectionWarning: UnexpectedParameter: Unexpected key 'database' found in params
    at ParamValidator.fail (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/param_validator.js:50:37)
    at ParamValidator.validateStructure (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/param_validator.js:77:14)
    at ParamValidator.validateMember (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/param_validator.js:88:21)
    at ParamValidator.validate (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/param_validator.js:34:10)
    at Request.VALIDATE_PARAMETERS (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/event_listeners.js:126:42)
    at Request.callListeners (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at callNextListener (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
    at /Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/event_listeners.js:86:9
    at finish (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/config.js:349:7)
    at /Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/config.js:367:9
    at SharedIniFileCredentials.get (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/credentials.js:127:7)
    at getAsyncCredentials (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/config.js:361:24)
    at Config.getCredentials (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/config.js:381:9)
    at Request.VALIDATE_CREDENTIALS (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/event_listeners.js:81:26)
    at Request.callListeners (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/sequential_executor.js:102:18)
    at Request.emit (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at Request.runTo (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/request.js:403:15)
    at /Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/request.js:792:12
    at new Promise (<anonymous>)
    at Request.promise (/Users/saminshams/Sites/eevee/node_modules/aws-sdk/lib/request.js:778:12)
    at Object.rollbackTransaction (/Users/saminshams/Sites/eevee/node_modules/data-api-client/index.js:495:9)
```

When debugging, I found that `mergeConfig(pick(config,['resourceArn','secretArn']),args)` still has a `database: undefined` passed to the `config.RDS.rollbackTransaction` method, which causes the error.