### PR TITLE
Fix mergeConfig - broader fix to Unexpected key 'database' found in params

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ const sqlString = require('sqlstring')
 
   // Merge configuration data with supplied arguments
   const mergeConfig = ({secretArn,resourceArn,database},args) =>
-    Object.assign({secretArn,resourceArn,database},args)
+    Object.assign({secretArn,resourceArn}, database ? {database} : {},args)
 
 
 


### PR DESCRIPTION
So that commitTransaction and rollbackTransaction work (they don't want database settings).