### PR TITLE
Remove options that are provided by the AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,13 @@ Below is a table containing all of the possible configuration options for the `d
 | secretArn | `string` | The ARN of the secret associated with your database credentials. This is *required*, but can be overridden when querying. |  |
 | database | `string` | *Optional* default database to use with queries. Can be overridden when querying. |  |
 | hydrateColumnNames | `boolean` | When `true`, results will be returned as objects with column names as keys. If `false`, results will be returned as an array of values. | `true` |
-| keepAlive | `boolean` | Enables HTTP Keep-Alive for calls to the AWS SDK. This dramatically decreases the latency of subsequent calls. | `true` |
-| sslEnabled | `boolean` | *Optional* Enables SSL HTTP endpoint. Can be disable for local development. | `true` |
 | options | `object` | An *optional* configuration object that is passed directly into the RDSDataService constructor. See [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDSDataService.html#constructor-property) for available options.  | `{}` |
-| region | `string`  | *Optional* AWS region to use. | `aws-sdk default` |
+
+### Connection Reuse
+
+It is recommended to enable connection reuse as this dramatically decreases the latency of subsequent calls to the AWS API. This can be done by setting an environment variable
+`AWS_NODEJS_CONNECTION_REUSE_ENABLED=1`. For more information see the [AWS SDK documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html).
+
 
 ## How to use this module
 

--- a/index.js
+++ b/index.js
@@ -31,21 +31,6 @@ const supportedTypes = [
   'structValue'
 ]
 
-/**********************************************************************/
-/** Enable HTTP Keep-Alive per https://vimeo.com/287511222          **/
-/** This dramatically increases the speed of subsequent HTTP calls  **/
-/**********************************************************************/
-
-const https = require('https')
-
-const sslAgent = new https.Agent({
-  keepAlive: true,
-  maxSockets: 50, // same as aws-sdk
-  rejectUnauthorized: true  // same as aws-sdk
-})
-sslAgent.setMaxListeners(0) // same as aws-sdk
-
-
 /********************************************************************/
 /**  PRIVATE METHODS                                               **/
 /********************************************************************/
@@ -446,23 +431,6 @@ module.exports = (params) => {
   const options = typeof params.options === 'object' ? params.options
     : params.options !== undefined ? error('\'options\' must be an object')
     : {}
-
-  // Update the default AWS http agent with our new sslAgent
-  if (typeof params.keepAlive === 'boolean' ? params.keepAlive : true) {
-    AWS.config.update({ httpOptions: { agent: sslAgent } })
-  }
-
-  // Update the AWS http agent with the region
-  if (typeof params.region === 'string') {
-    AWS.config.update({ region: params.region })
-  }
-
-  // Disable ssl if wanted for local development
-  if (params.sslEnabled === false) {
-    // AWS.config.update({ sslEnabled: false })
-    options.sslEnabled = false
-  }
-
 
   // Set the configuration for this instance
   const config = {


### PR DESCRIPTION
Fixes https://github.com/jeremydaly/data-api-client/issues/33

* The `keepAlive` option is better served by setting the environment variable `AWS_NODEJS_CONNECTION_REUSE_ENABLED=1` and removes the need to configure a custom Agent.
* The `sslEnabled` option is simply passed straight through to the underlying `RDSDataConnection` anyway so doesn't add anything.
* The `region` option can also be set by passing a value using the `options` param, and probably shouldn't be setting the global region any way.