### PR TITLE
Add support for arrayValues and arrayValue for querying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
-# Dependency directories
-node_modules
+# Dependencies
+**/node_modules/
 
-# Optional npm cache directory
-.npm
+# Environment
+**/.env
 
-dump.rdb
+# Logs
+**/npm-debug.log*
+**/.npm
+**/dump.rdb
+
+# Editors and IDEs
+**/.idea
+**/.vscode/*
+
+# Misc
+**/.DS_Store

--- a/index.test.js
+++ b/index.test.js
@@ -519,7 +519,7 @@ describe('querying', () => {
     const formatRecords = dataApiClient.__get__('formatRecords')
 
     test('with columnMetadata', async () => {
-      let { records, columnMetadata } = require('./test/sample-query-response.json')
+      let { records, columnMetadata } = require('./test/sample-format-records.json')
       let result = formatRecords(records, columnMetadata)
       expect(result).toEqual([
         {
@@ -528,7 +528,8 @@ describe('querying', () => {
           description: null,
           id: 1,
           modified: '2019-11-12 22:15:25',
-          name: 'Category 1'
+          name: 'Category 1',
+          roles: []
         },
         {
           created: '2019-11-12 22:17:11',
@@ -536,17 +537,28 @@ describe('querying', () => {
           description: 'Description of Category 2',
           id: 2,
           modified: '2019-11-12 22:21:36',
-          name: 'Category 2'
+          name: 'Category 2',
+          roles: ["foo", "bar"]
+        },
+        {
+          created: '2019-11-12 22:17:11',
+          deleted: null,
+          description: 'Description of Category 3',
+          id: 3,
+          modified: '2019-11-12 22:21:44',
+          name: 'Category 3',
+          roles: [["foo", "bar"], ["biz", "baz"]]
         }
       ])
     })
 
     test('without columnMetadata', async () => {
-      let { records } = require('./test/sample-query-response.json')
+      let { records } = require('./test/sample-format-records.json')
       let result = formatRecords(records, false)
       expect(result).toEqual([
-        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
-        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
+        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null, [] ],
+        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null, ["foo", "bar"] ],
+        [ 3, 'Category 3', 'Description of Category 3', '2019-11-12 22:17:11', '2019-11-12 22:21:44', null, [["foo", "bar"], ["biz", "baz"]] ]
       ])
     })
   }) // end formatRecords

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -1605,9 +1605,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         }
       }
@@ -3878,9 +3878,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         }
       }
@@ -3943,9 +3943,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "test-ci": "eslint . && jest",
-    "lint": "eslint ."
+    "lint": "eslint . --fix"
   },
   "repository": {
     "type": "git",

--- a/test/sample-format-records.json
+++ b/test/sample-format-records.json
@@ -1,0 +1,188 @@
+{
+  "columnMetadata": [
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": true,
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "id",
+      "name": "id",
+      "nullable": 0,
+      "precision": 10,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 4,
+      "typeName": "INT UNSIGNED"
+    },
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": false,
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "name",
+      "name": "name",
+      "nullable": 1,
+      "precision": 100,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 12,
+      "typeName": "VARCHAR"
+    },
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": false,
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "description",
+      "name": "description",
+      "nullable": 1,
+      "precision": 255,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 12,
+      "typeName": "VARCHAR"
+    },
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": false,
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "created",
+      "name": "created",
+      "nullable": 0,
+      "precision": 19,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 93,
+      "typeName": "TIMESTAMP"
+    },
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": false,
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "modified",
+      "name": "modified",
+      "nullable": 0,
+      "precision": 19,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 93,
+      "typeName": "TIMESTAMP"
+    },
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": false,
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "deleted",
+      "name": "deleted",
+      "nullable": 1,
+      "precision": 19,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 93,
+      "typeName": "TIMESTAMP"
+    },
+    {
+      "arrayBaseColumnType": 0,
+      "isAutoIncrement": false,
+      "isCaseSensitive": true,
+      "isCurrency": false,
+      "isSigned": false,
+      "label": "roles",
+      "name": "roles",
+      "nullable": 0,
+      "precision": 2147483647,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "cats",
+      "type": 2003,
+      "typeName": "_text"
+    }
+  ],
+  "numberOfRecordsUpdated": 0,
+  "records": [
+    [
+      {
+        "longValue": 1
+      },
+      {
+        "stringValue": "Category 1"
+      },
+      {
+        "isNull": true
+      },
+      {
+        "stringValue": "2019-11-12 22:00:11"
+      },
+      {
+        "stringValue": "2019-11-12 22:15:25"
+      },
+      {
+        "isNull": true
+      },
+      {
+        "arrayValue": {"stringValue":  []}
+      }
+    ],
+    [
+      {
+        "longValue": 2
+      },
+      {
+        "stringValue": "Category 2"
+      },
+      {
+        "stringValue": "Description of Category 2"
+      },
+      {
+        "stringValue": "2019-11-12 22:17:11"
+      },
+      {
+        "stringValue": "2019-11-12 22:21:36"
+      },
+      {
+        "isNull": true
+      },
+      {
+        "arrayValue": {"stringValue":  ["foo", "bar"]}
+      }
+    ],
+    [
+      {
+        "longValue": 3
+      },
+      {
+        "stringValue": "Category 3"
+      },
+      {
+        "stringValue": "Description of Category 3"
+      },
+      {
+        "stringValue": "2019-11-12 22:17:11"
+      },
+      {
+        "stringValue": "2019-11-12 22:21:44"
+      },
+      {
+        "isNull": true
+      },
+      {
+        "arrayValue": {"arrayValues": [{"stringValue": ["foo", "bar"]}, {"stringValue": ["biz", "baz"]}]}
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Supports [Array types](https://www.postgresql.org/docs/9.1/arrays.html) when formatting the response. From what I could test, updating Array values already works in this repo, it's the response which is wrong when selecting them. 

I'm aware that there is a branch dedicated for Postgres support, but this felt a bit more general purpose, since implementing it is not a breaking change. 

Solves #42 