### PR TITLE
Typecasting support for Postgres

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,38 +1,37 @@
 {
   "env": {
-      "es6": true,
-      "node": true
+    "es6": true,
+    "node": true
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-      "ecmaVersion": 8,
-      "sourceType": "module"
+    "ecmaVersion": 8,
+    "sourceType": "module"
   },
   "rules": {
-      "indent": [
-          "error",
-          2
-      ],
-      "linebreak-style": [
-          "error",
-          "unix"
-      ],
-      "quotes": [
-          "error",
-          "single"
-      ],
-      "semi": [
-          "error",
-          "never"
-      ],
-      "indent": [
-        "error",
-        2,
-        { "SwitchCase": 1, "flatTernaryExpressions": true }
-      ]
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "never"
+    ],
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1,
+        "flatTernaryExpressions": true
+      }
+    ]
   },
   "globals": {
-      "expect": true,
-      "it": true
+    "expect": true,
+    "it": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 .npm
 
 dump.rdb
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -236,6 +236,35 @@ SELECT `id`, `name`, `created` FROM `table_123abc` WHERE id > :id LIMIT 10
 
 You'll notice that we leave the *named parameters* alone. Anything that Data API and the `RDSDataService` Class currently handles, we defer to them.
 
+### Type-Casting
+The Aurora Data API can sometimes give you trouble with certain data types, such as uuid, unless you explicitly cast them. While you can certainly do this manually in your SQL string, the Data API Client offers a really easy way to handle this for you.
+
+```javascript
+const result = await data.query(
+  'INSERT INTO users(id, email, full_name, metadata) VALUES(:id, :email, :fullName, :metadata)',
+  [
+    {
+      name: 'id',
+      value: newUserId,
+      cast: 'uuid'
+    },
+    {
+      name: 'email',
+      value: email
+    },
+    {
+      name: 'fullName',
+      value: fullName
+    },
+    {
+      name: 'metadata',
+      value: JSON.stringify(userMetadata),
+      cast: 'jsonb'
+    }
+  ]
+)
+```
+
 ### Batch Queries
 The `RDSDataService` Class provides a `batchExecuteStatement` method that allows you to execute a prepared statement multiple times using different parameter sets. This is only allowed for `INSERT`, `UPDATE` and `DELETE` queries, but is much more efficient than issuing multiple `executeStatement` calls. The Data API Client handles the switching for you based on *how* you send in your parameters.
 

--- a/index.js
+++ b/index.js
@@ -104,27 +104,39 @@ const pick = (obj,values) => Object.keys(obj).reduce((acc,x) =>
 const flatten = arr => arr.reduce((acc,x) => acc.concat(x),[])
 
 // Normize parameters so that they are all in standard format
-const normalizeParams = params => params.reduce((acc,p) =>
+const normalizeParams = params => params.reduce((acc, p) =>
   Array.isArray(p) ? acc.concat([normalizeParams(p)])
-  : Object.keys(p).length === 2 && p.name && p.value ? acc.concat(p)
-  : acc.concat(splitParams(p))
-,[]) // end reduce
+  : (
+    (Object.keys(p).length === 2 && p.name && p.value) ||
+    (Object.keys(p).length === 3 && p.name && p.value && p.cast)
+  ) ? acc.concat(p)
+    : acc.concat(splitParams(p))
+, []) // end reduce
 
 
 // Prepare parameters
-const processParams = (sql,sqlParams,params,formatOptions,row=0) => {
+const processParams = (engine,sql,sqlParams,params,formatOptions,row=0) => {
   return {
     processedParams: params.reduce((acc,p) => {
       if (Array.isArray(p)) {
-        let result = processParams(sql,sqlParams,p,formatOptions,row)
+        const result = processParams(sql,sqlParams,p,formatOptions,row)
         if (row === 0) { sql = result.escapedSql; row++ }
         return acc.concat([result.processedParams])
       } else if (sqlParams[p.name]) {
         if (sqlParams[p.name].type === 'n_ph') {
+          if (p.cast) {
+            const regex = new RegExp(':' + p.name + '\\b', 'g')
+            sql = sql.replace(
+              regex,
+              engine === 'pg'
+                ? `:${p.name}::${p.cast}`
+                : `CAST(:${p.name} AS ${p.cast})`
+            )
+          }
           acc.push(formatParam(p.name,p.value,formatOptions))
         } else if (row === 0) {
-          let regex = new RegExp('::' + p.name + '\\b','g')
-          sql = sql.replace(regex,sqlString.escapeId(p.value))
+          const regex = new RegExp('::' + p.name + '\\b', 'g')
+          sql = sql.replace(regex, sqlString.escapeId(p.value))
         }
         return acc
       } else {
@@ -184,7 +196,7 @@ const getType = val =>
 // Hint to specify the underlying object type for data type mapping
 const getTypeHint = val =>
   isDate(val) ? 'TIMESTAMP' : undefined
-  
+
 const isDate = val =>
   val instanceof Date
 
@@ -256,7 +268,7 @@ const formatResults = (
 
 // Processes records and either extracts Typed Values into an array, or
 // object with named column labels
-const formatRecords = (recs,columns,hydrate,formatOptions) => {  
+const formatRecords = (recs,columns,hydrate,formatOptions) => {
 
   // Create map for efficient value parsing
   let fmap = recs && recs[0] ? recs[0].map((x,i) => {
@@ -306,8 +318,8 @@ const formatRecords = (recs,columns,hydrate,formatOptions) => {
 
 // Format record value based on its value, the database column's typeName and the formatting options
 const formatRecordValue = (value,typeName,formatOptions) => formatOptions && formatOptions.deserializeDate &&
-  ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMP WITH TIME ZONE'].includes(typeName) 
-  ? formatFromTimeStamp(value,(formatOptions && formatOptions.treatAsLocalDate) || typeName === 'TIMESTAMP WITH TIME ZONE') 
+  ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMP WITH TIME ZONE'].includes(typeName)
+  ? formatFromTimeStamp(value,(formatOptions && formatOptions.treatAsLocalDate) || typeName === 'TIMESTAMP WITH TIME ZONE')
   : value
 
 // Format updateResults and extract insertIds
@@ -329,7 +341,6 @@ const mergeConfig = (initialConfig,args) =>
 
 // Query function (use standard form for `this` context)
 const query = async function(config,..._args) {
-
   // Flatten array if nested arrays (fixes #30)
   const args = Array.isArray(_args[0]) ? flatten(_args) : _args
 
@@ -347,11 +358,11 @@ const query = async function(config,..._args) {
   const parameters = normalizeParams(parseParams(args))
 
   // Process parameters and escape necessary SQL
-  const { processedParams,escapedSql } = processParams(sql,sqlParams,parameters,formatOptions)
+  const { processedParams,escapedSql } = processParams(config.engine,sql,sqlParams,parameters,formatOptions)
 
   // Determine if this is a batch request
   const isBatch = processedParams.length > 0
-    && Array.isArray(processedParams[0]) ? true : false
+    && Array.isArray(processedParams[0])
 
   // Create/format the parameters
   const params = Object.assign(
@@ -482,10 +493,13 @@ const commit = async (config,queries,rollback) => {
  * @param {object} params
  * @param {'mysql'|'pg'} params.engine The type of database (MySQL or Postgres)
  * @param {string} params.resourceArn The ARN of your Aurora Serverless Cluster
- * @param {string} params.secretArn The ARN of the secret associated with your database credentials
+ * @param {string} params.secretArn The ARN of the secret associated with your
+ *   database credentials
  * @param {string} [params.database] The name of the database
- * @param {boolean} [params.hydrateColumnNames=true] Return objects with column names as keys
- * @param {object} [params.options={}] Configuration object passed directly into RDSDataService
+ * @param {boolean} [params.hydrateColumnNames=true] Return objects with column
+ *   names as keys
+ * @param {object} [params.options={}] Configuration object passed directly
+ *   into RDSDataService
  * @param {object} [params.formatOptions] Date-related formatting options
  * @param {boolean} [params.formatOptions.deserializeDate=false]
  * @param {boolean} [params.formatOptions.treatAsLocalDate=false]
@@ -494,7 +508,7 @@ const commit = async (config,queries,rollback) => {
  * @param {string} [params.region] DEPRECATED
  *
  */
-function init(params) {
+const init = params => {
 
   // Set the options for the RDSDataService
   const options = typeof params.options === 'object' ? params.options
@@ -513,6 +527,10 @@ function init(params) {
 
   // Set the configuration for this instance
   const config = {
+    // Require engine
+    engine: typeof params.engine === 'string' ?
+      params.engine
+      : error('\'engine\' string value required'),
 
     // Require secretArn
     secretArn: typeof params.secretArn === 'string' ?
@@ -552,7 +570,7 @@ function init(params) {
     // Create an instance of RDSDataService
     RDS: new AWS.RDSDataService(options)
 
-  } // end config 
+  } // end config
 
   // Return public methods
   return {

--- a/index.js
+++ b/index.js
@@ -489,7 +489,7 @@ const commit = async (config,queries,rollback) => {
 
 // Export main function
 /**
- *
+ * Create a Data API client instance
  * @param {object} params
  * @param {'mysql'|'pg'} params.engine The type of database (MySQL or Postgres)
  * @param {string} params.resourceArn The ARN of your Aurora Serverless Cluster

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const processParams = (engine,sql,sqlParams,params,formatOptions,row=0) => {
   return {
     processedParams: params.reduce((acc,p) => {
       if (Array.isArray(p)) {
-        const result = processParams(sql,sqlParams,p,formatOptions,row)
+        const result = processParams(engine,sql,sqlParams,p,formatOptions,row)
         if (row === 0) { sql = result.escapedSql; row++ }
         return acc.concat([result.processedParams])
       } else if (sqlParams[p.name]) {

--- a/index.js
+++ b/index.js
@@ -380,7 +380,7 @@ const query = async function(config,..._args) {
     return formatResults(
       result,
       hydrateColumnNames,
-      args[0].includeResultMetadata === true ? true : false,
+      args[0].includeResultMetadata === true,
       formatOptions
     )
 
@@ -477,7 +477,24 @@ const commit = async (config,queries,rollback) => {
 /********************************************************************/
 
 // Export main function
-module.exports = (params) => {
+/**
+ *
+ * @param {object} params
+ * @param {'mysql'|'pg'} params.engine The type of database (MySQL or Postgres)
+ * @param {string} params.resourceArn The ARN of your Aurora Serverless Cluster
+ * @param {string} params.secretArn The ARN of the secret associated with your database credentials
+ * @param {string} [params.database] The name of the database
+ * @param {boolean} [params.hydrateColumnNames=true] Return objects with column names as keys
+ * @param {object} [params.options={}] Configuration object passed directly into RDSDataService
+ * @param {object} [params.formatOptions] Date-related formatting options
+ * @param {boolean} [params.formatOptions.deserializeDate=false]
+ * @param {boolean} [params.formatOptions.treatAsLocalDate=false]
+ * @param {boolean} [params.keepAlive] DEPRECATED
+ * @param {boolean} [params.sslEnabled=true] DEPRECATED
+ * @param {string} [params.region] DEPRECATED
+ *
+ */
+function init(params) {
 
   // Set the options for the RDSDataService
   const options = typeof params.options === 'object' ? params.options
@@ -568,3 +585,5 @@ module.exports = (params) => {
   }
 
 } // end exports
+
+module.exports = init

--- a/index.test.js
+++ b/index.test.js
@@ -375,6 +375,7 @@ describe('query parameter processing', () => {
 
     test('single param, single record', async () => {
       let { processedParams,escapedSql } = processParams(
+        'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' } },
         [{ name: 'id', value: 1 }]
@@ -387,6 +388,7 @@ describe('query parameter processing', () => {
 
     test('mulitple params, named param, single record', async () => {
       let { processedParams,escapedSql } = processParams(
+        'pg',
         'SELECT ::columnName FROM myTable WHERE id = :id AND id2 = :id2',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' }, columnName: { type: 'n_id' } },
         [
@@ -404,6 +406,7 @@ describe('query parameter processing', () => {
 
     test('single param, multiple records', async () => {
       let { processedParams,escapedSql } = processParams(
+        'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' } },
         [
@@ -420,6 +423,7 @@ describe('query parameter processing', () => {
 
     test('multiple params, multiple records', async () => {
       let { processedParams,escapedSql } = processParams(
+        'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' } },
         [
@@ -436,6 +440,7 @@ describe('query parameter processing', () => {
 
     test('mulitple params, named params, multiple records', async () => {
       let { processedParams,escapedSql } = processParams(
+        'pg',
         'SELECT ::columnName FROM myTable WHERE id = :id AND id2 = :id2',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' }, columnName: { type: 'n_id' } },
         [
@@ -461,6 +466,25 @@ describe('query parameter processing', () => {
           { name: 'id', value: { longValue: 2 } },
           { name: 'id2', value: { longValue: 3 } }
         ]
+      ])
+    })
+
+    test('typecasting params', async () => {
+      let { processedParams,escapedSql } = processParams(
+        'pg',
+        'INSERT INTO users(id, name, meta) VALUES(:id, :name, :meta)',
+        { id: { type: 'n_ph' }, name: { type: 'n_ph' }, meta: { type: 'n_ph' } },
+        [
+          { name: 'id', value: '0bb99248-2e7d-4007-a4b2-579b00649ce1', cast: 'uuid' },
+          { name: 'name', value: 'Test' },
+          { name: 'meta', value: '{"extra": true}', cast: 'jsonb' }
+        ]
+      )
+      expect(escapedSql).toBe('INSERT INTO users(id, name, meta) VALUES(:id::uuid, :name, :meta::jsonb)')
+      expect(processedParams).toEqual([
+        { name: 'id', value: { stringValue: '0bb99248-2e7d-4007-a4b2-579b00649ce1' } },
+        { name: 'name', value: { stringValue: 'Test' } },
+        { name: 'meta', value: { stringValue: '{"extra": true}' } }
       ])
     })
 


### PR DESCRIPTION
It's clear based on several open issues that the Aurora Data API is a bit clunky when it comes to handling certain data types (`jsonb`, `uuid`, etc.). This PR's goal will be to allow specifying a `cast` property in `parameters` to allow casting certain fields as needed.

If anyone has input, please contribute by commenting on this PR, and I'm happy to discuss any potential changes to the code.