### PR TITLE
RDS Data API policy actions do not support resource-level permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Statement:
       - "rds-data:BeginTransaction"
       - "rds-data:RollbackTransaction"
       - "rds-data:CommitTransaction"
-    Resource: "arn:aws:rds:{REGION}:{ACCOUNT-ID}:cluster:{YOUR-CLUSTER-NAME}"
+    Resource: "*"
   - Effect: "Allow"
     Action:
       - "secretsmanager:GetSecretValue"
@@ -411,7 +411,7 @@ Statement:
       "rds-data:RollbackTransaction",
       "rds-data:CommitTransaction"
     ],
-    "Resource": "arn:aws:rds:{REGION}:{ACCOUNT-ID}:cluster:{YOUR-CLUSTER-NAME}"
+    "Resource": "*"
   },
   {
     "Effect": "Allow",


### PR DESCRIPTION
Fix #64 

Use `"Resource": "*"` in IAM policy because RDS Data API actions do not support resource-level permissions.

See https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonrdsdataapi.html#amazonrdsdataapi-resources-for-iam-policies