### PR TITLE
Fix Date type support when using Aurora PostgreSQL

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ const formatRecords = (recs,columns,hydrate,formatOptions) => {
 
 // Format record value based on its value, the database column's typeName and the formatting options
 const formatRecordValue = (value,typeName,formatOptions) => formatOptions && formatOptions.deserializeDate &&
-  ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMP WITH TIME ZONE'].includes(typeName)
+  ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE'].includes(typeName.toUpperCase())
   ? formatFromTimeStamp(value,(formatOptions && formatOptions.treatAsLocalDate) || typeName === 'TIMESTAMP WITH TIME ZONE')
   : value
 


### PR DESCRIPTION
This change fixes the `deserializeDate` format option functionality when using Aurora PostgreSQL. From there the type names arrive in lowercase and you also have the `timestamptz` abbreviation for `timestamp with time zone`.