### PR TITLE
Fix #110 by changing date format detection regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ const formatToTimeStamp = (date, treatAsLocalDate) => {
 // If standard TIMESTAMP format (YYYY-MM-DD[ HH:MM:SS[.FFF]]) without TZ + treatAsLocalDate=false then assume UTC Date
 // In all other cases convert value to datetime as-is (also values with TZ info)
 const formatFromTimeStamp = (value,treatAsLocalDate) =>
-  !treatAsLocalDate && /^\d{4}-\d{2}-\d{2}(\s\d{2}:\d{2}:\d{2}(\.\d{3})?)?$/.test(value) ?
+  !treatAsLocalDate && /^\d{4}-\d{2}-\d{2}(\s\d{2}:\d{2}:\d{2}(\.\d+)?)?$/.test(value) ?
     new Date(value + 'Z') :
     new Date(value)
 


### PR DESCRIPTION
Bugfix to close #110 

Allows any number of fractional seconds when detecting datetime format, instead of just 3, which leads to bugs when mysql truncates trailing millisecond digits.