### PR TITLE
Externalizing aws-sdk instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,8 +361,6 @@ const data = require('data-api-client')({
 })
 ```
 
-or mocking AWS for testing.
-
 ## Data API Limitations / Wonkiness
 The first GA release of the Data API has *a lot* of promise, unfortunately, there are still quite a few things that make it a bit wonky and may require you to implement some workarounds. I've outlined some of my findings below.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Below is a table containing all of the possible configuration options for the `d
 
 | Property | Type | Description | Default |
 | -------- | ---- | ----------- | ------- |
+| AWS      | `AWS` |  A custom `aws-sdk` instance   |         |
 | resourceArn | `string` | The ARN of your Aurora Serverless Cluster. This value is *required*, but can be overridden when querying. |  |
 | secretArn | `string` | The ARN of the secret associated with your database credentials. This is *required*, but can be overridden when querying. |  |
 | database | `string` | *Optional* default database to use with queries. Can be overridden when querying. |  |
@@ -335,6 +336,32 @@ let result = await data.executeStatement({
   transactionId: 'AQC5SRDIm...ZHXP/WORU='
 )
 ```
+
+## Custom AWS instance
+
+`data-api-client` allows for introducing a custom `AWS` as a parameter. This parameter is optional. If not present - `data-api-client` will fall back to the default `AWS` instance that comes with the library.
+
+```javascript
+// Instantiate data-api-client with a custom AWS instance
+const data = require('data-api-client')({
+  AWS: customAWS,
+  ...
+})
+```
+
+Custom AWS parameter allows to introduce, e.g. tracing Data API calls through X-Ray with:
+
+```javascript
+const AWSXRay = require('aws-xray-sdk')
+const AWS = AWSXRay.captureAWS(require('aws-sdk'))
+
+const data = require('data-api-client')({
+  AWS: AWS,
+  ...
+})
+```
+
+or mocking AWS for testing.
 
 ## Data API Limitations / Wonkiness
 The first GA release of the Data API has *a lot* of promise, unfortunately, there are still quite a few things that make it a bit wonky and may require you to implement some workarounds. I've outlined some of my findings below.

--- a/index.js
+++ b/index.js
@@ -567,7 +567,7 @@ const init = params => {
 
     // TODO: Put this in a separate module for testing?
     // Create an instance of RDSDataService
-    RDS: new AWS.RDSDataService(options)
+    RDS: params.AWS ? new params.AWS.RDSDataService(options) : new AWS.RDSDataService(options)
 
   } // end config
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A lightweight wrapper that simplifies working with the Amazon Aurora Serverless Data API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change allows to introduce `AWS` as a parameter. The parameter is optional, but if present - will be used instead of the default `AWS` instance to create the `RDSDataService`. With this - one can enable X-Ray tracing (which was the primary objective of the PR), yet it is not breaking any existing usage.