### PR TITLE
fix(pg): handle pg engine lowercase typeName

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,16 +358,18 @@ const formatRecords = (recs, columns, hydrate, formatOptions) => {
 
 // Format record value based on its value, the database column's typeName and the formatting options
 const formatRecordValue = (value, typeName, formatOptions) => {
+  const standardizedTypeName = typeName ? typeName.toUpperCase() : typeName
+
   if (
     formatOptions &&
     formatOptions.deserializeDate &&
-    ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE'].includes(typeName.toUpperCase())
+    ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE'].includes(standardizedTypeName)
   ) {
     return formatFromTimeStamp(
       value,
-      (formatOptions && formatOptions.treatAsLocalDate) || typeName === 'TIMESTAMP WITH TIME ZONE'
+      (formatOptions && formatOptions.treatAsLocalDate) || standardizedTypeName === 'TIMESTAMP WITH TIME ZONE'
     )
-  } else if (typeName === 'JSON') {
+  } else if (standardizedTypeName === 'JSON') {
     return JSON.parse(value)
   } else {
     return value

--- a/index.test.js
+++ b/index.test.js
@@ -573,6 +573,34 @@ describe('querying', () => {
         [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
       ])
     })
+
+    test('with pg lowercase typeName', async () => {
+      let { records, columnMetadata } = require('./test/sample-query-response.json')
+
+      columnMetadata.forEach(metadata => {
+        metadata.typeName = metadata.typeName.toLowerCase()
+      })
+
+      let result = formatRecords(records, columnMetadata, true)
+      expect(result).toEqual([
+        {
+          created: '2019-11-12 22:00:11',
+          deleted: null,
+          description: null,
+          id: 1,
+          modified: '2019-11-12 22:15:25',
+          name: 'Category 1'
+        },
+        {
+          created: '2019-11-12 22:17:11',
+          deleted: null,
+          description: 'Description of Category 2',
+          id: 2,
+          modified: '2019-11-12 22:21:36',
+          name: 'Category 2'
+        }
+      ])
+    })
   }) // end formatRecords
 
 


### PR DESCRIPTION
aurora serverless with postgresql returns `typeName` as lowercase. because of this, the function `formatRecordValue` does not function properly for pg responses.

to fix, I cast the `typeName` to uppercase at the start of the function, storing it in a new const `standardizedTypeName`.
added a test case to cover this issue.