### PR TITLE
Fix type name handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,16 +351,18 @@ const formatRecords = (recs, columns, hydrate, formatOptions) => {
 
 // Format record value based on its value, the database column's typeName and the formatting options
 const formatRecordValue = (value, typeName, formatOptions) => {
+  const standardizedTypeName = typeName ? typeName.toUpperCase() : typeName
+
   if (
     formatOptions &&
     formatOptions.deserializeDate &&
-    ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE'].includes(typeName.toUpperCase())
+    ['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE'].includes(standardizedTypeName)
   ) {
     return formatFromTimeStamp(
       value,
-      (formatOptions && formatOptions.treatAsLocalDate) || typeName === 'TIMESTAMP WITH TIME ZONE'
+      (formatOptions && formatOptions.treatAsLocalDate) || standardizedTypeName === 'TIMESTAMP WITH TIME ZONE'
     )
-  } else if (typeName === 'JSON') {
+  } else if (standardizedTypeName === 'JSON') {
     return JSON.parse(value)
   } else {
     return value

--- a/index.test.js
+++ b/index.test.js
@@ -12,7 +12,6 @@ const dataApiClient = rewire('./index')
 // })
 
 describe('utility', () => {
-
   test('error', async () => {
     const error = dataApiClient.__get__('error')
     let err = () => error('test error')
@@ -21,29 +20,25 @@ describe('utility', () => {
 
   test('omit', async () => {
     const omit = dataApiClient.__get__('omit')
-    let result = omit({ a: 1, b: 2, c: 3},['c'])
+    let result = omit({ a: 1, b: 2, c: 3 }, ['c'])
     expect(result).toEqual({ a: 1, b: 2 })
   })
 
   test('pick', async () => {
     const pick = dataApiClient.__get__('pick')
-    let result = pick({ a: 1, b: 2, c: 3},['a','c'])
+    let result = pick({ a: 1, b: 2, c: 3 }, ['a', 'c'])
     expect(result).toEqual({ a: 1, c: 3 })
   })
 
   test('flatten', async () => {
     const flatten = dataApiClient.__get__('flatten')
-    let result = flatten([[1,2,3],4,[5,6],7,8])
-    expect(result).toEqual([1,2,3,4,5,6,7,8])
+    let result = flatten([[1, 2, 3], 4, [5, 6], 7, 8])
+    expect(result).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
   })
-
 }) // end utility
 
-
 describe('query parsing', () => {
-
   describe('parseSQL', () => {
-
     const parseSQL = dataApiClient.__get__('parseSQL')
 
     test('string', async () => {
@@ -62,29 +57,27 @@ describe('query parsing', () => {
     })
   }) // end parseSQL
 
-
   describe('parseParams', () => {
-
     const parseParams = dataApiClient.__get__('parseParams')
 
     test('array', async () => {
-      let result = parseParams(['query',[1,2]])
-      expect(result).toEqual([1,2])
+      let result = parseParams(['query', [1, 2]])
+      expect(result).toEqual([1, 2])
     })
 
     test('object', async () => {
-      let result = parseParams(['query', { a: 1, b: 2}])
-      expect(result).toEqual([{ a:1, b:2 }])
+      let result = parseParams(['query', { a: 1, b: 2 }])
+      expect(result).toEqual([{ a: 1, b: 2 }])
     })
 
     test('array (in object)', async () => {
-      let result = parseParams([{ parameters: [1,2,3] }])
-      expect(result).toEqual([1,2,3])
+      let result = parseParams([{ parameters: [1, 2, 3] }])
+      expect(result).toEqual([1, 2, 3])
     })
 
     test('object (in object)', async () => {
-      let result = parseParams([{ parameters: { a: 1, b: 2} }])
-      expect(result).toEqual([{ a:1, b:2 }])
+      let result = parseParams([{ parameters: { a: 1, b: 2 } }])
+      expect(result).toEqual([{ a: 1, b: 2 }])
     })
 
     test('no params (empty array)', async () => {
@@ -93,12 +86,12 @@ describe('query parsing', () => {
     })
 
     test('no params in object (empty array)', async () => {
-      let result = parseParams([{ }])
+      let result = parseParams([{}])
       expect(result).toEqual([])
     })
 
     test('invalid type (error)', async () => {
-      let result = () => parseParams(['query','string'])
+      let result = () => parseParams(['query', 'string'])
       expect(result).toThrow('Parameters must be an object or array')
     })
 
@@ -106,26 +99,21 @@ describe('query parsing', () => {
       let result = () => parseParams([{ parameters: 'string' }])
       expect(result).toThrow(`'parameters' must be an object or array`)
     })
-
   }) // end parse params
-
 }) // end query parsing
 
-
 describe('query configuration parsing', () => {
-
   test('mergeConfig', async () => {
     const mergeConfig = dataApiClient.__get__('mergeConfig')
-    let result = mergeConfig({ secretArn:'secretArn',resourceArn:'resourceArn' }, { database: 'db' })
-    expect(result).toEqual({ secretArn:'secretArn',resourceArn:'resourceArn', database: 'db' })
+    let result = mergeConfig({ secretArn: 'secretArn', resourceArn: 'resourceArn' }, { database: 'db' })
+    expect(result).toEqual({ secretArn: 'secretArn', resourceArn: 'resourceArn', database: 'db' })
   })
 
   describe('parseDatabase', () => {
-
     const parseDatabase = dataApiClient.__get__('parseDatabase')
 
     test('from config w/ transaction', async () => {
-      let result = parseDatabase({ database: 'db', transactionId: 'txid'})
+      let result = parseDatabase({ database: 'db', transactionId: 'txid' })
       expect(result).toBe('db')
     })
 
@@ -148,53 +136,45 @@ describe('query configuration parsing', () => {
       let result = parseDatabase({}, [{}])
       expect(result).toBe.undefined
     })
-
   }) // end parseDatabase
 
   describe('parseHydrate', () => {
-
     const parseHydrate = dataApiClient.__get__('parseHydrate')
 
     test('parseHydrate - from args', async () => {
-      let result = parseHydrate({ hydrateColumnNames: true },[{ hydrateColumnNames: false }])
+      let result = parseHydrate({ hydrateColumnNames: true }, [{ hydrateColumnNames: false }])
       expect(result).toBe(false)
     })
 
     test('parseHydrate - from config', async () => {
-      let result = parseHydrate({ hydrateColumnNames: true },[{ }])
+      let result = parseHydrate({ hydrateColumnNames: true }, [{}])
       expect(result).toBe(true)
     })
 
     test('parseHydrate - from args, not boolean (error)', async () => {
-      let result = () => parseHydrate({ hydrateColumnNames: true },[{ hydrateColumnNames: 'false' }])
+      let result = () => parseHydrate({ hydrateColumnNames: true }, [{ hydrateColumnNames: 'false' }])
       expect(result).toThrow(`'hydrateColumnNames' must be a boolean.`)
     })
-
   })
 
-
   describe('prepareParams', () => {
-
     const prepareParams = dataApiClient.__get__('prepareParams')
 
     test('prepareParams - omit specific args, merge others', async () => {
-      let result = prepareParams({ secretArn:'secretArn',resourceArn:'resourceArn' },
-        [{ hydrateColumnNames: true, parameters: [1,2,3], test: true }])
+      let result = prepareParams({ secretArn: 'secretArn', resourceArn: 'resourceArn' }, [
+        { hydrateColumnNames: true, parameters: [1, 2, 3], test: true }
+      ])
       expect(result).toEqual({ secretArn: 'secretArn', resourceArn: 'resourceArn', test: true })
     })
 
     test('prepareParams - no args', async () => {
-      let result = prepareParams({ secretArn:'secretArn',resourceArn:'resourceArn' },[])
+      let result = prepareParams({ secretArn: 'secretArn', resourceArn: 'resourceArn' }, [])
       expect(result).toEqual({ secretArn: 'secretArn', resourceArn: 'resourceArn' })
     })
-
   }) // end prepareParams
-
 }) // end query config parsing
 
-
 describe('query parameter processing', () => {
-
   test('splitParams', async () => {
     const splitParams = dataApiClient.__get__('splitParams')
     let result = splitParams({ param1: 'p1', param2: 'p2' })
@@ -209,7 +189,7 @@ describe('query parameter processing', () => {
     let result = normalizeParams([
       { name: 'param1', value: 'p1' },
       { param2: 'p2' },
-      [ { name: 'param3', value: 'p3' }, { param4: 'p4'} ],
+      [{ name: 'param3', value: 'p3' }, { param4: 'p4' }],
       { name: 'param5', value: 'p5', param6: 'p6' }
     ])
     expect(result).toEqual([
@@ -226,39 +206,35 @@ describe('query parameter processing', () => {
   })
 
   describe('formatType', () => {
-
     const formatType = dataApiClient.__get__('formatType')
 
     test('stringValue', async () => {
-      let result = formatType('param','string val','stringValue')
-      expect(result).toEqual({ name: 'param', value: { stringValue: 'string val' }})
+      let result = formatType('param', 'string val', 'stringValue')
+      expect(result).toEqual({ name: 'param', value: { stringValue: 'string val' } })
     })
 
     test('booleanValue', async () => {
-      let result = formatType('param',true,'booleanValue')
-      expect(result).toEqual({ name: 'param', value: { booleanValue: true }})
+      let result = formatType('param', true, 'booleanValue')
+      expect(result).toEqual({ name: 'param', value: { booleanValue: true } })
     })
 
     test('longValue', async () => {
-      let result = formatType('param',1234567890,'longValue')
-      expect(result).toEqual({ name: 'param', value: { longValue: 1234567890 }})
+      let result = formatType('param', 1234567890, 'longValue')
+      expect(result).toEqual({ name: 'param', value: { longValue: 1234567890 } })
     })
 
     test('existing type', async () => {
-      let result = formatType('param',{ stringValue: 'string' },null)
-      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' }})
+      let result = formatType('param', { stringValue: 'string' }, null)
+      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' } })
     })
 
     test('undefined (error)', async () => {
-      let result = () => formatType('param','invalid type',undefined)
+      let result = () => formatType('param', 'invalid type', undefined)
       expect(result).toThrow(`'param' is an invalid type`)
     })
-
   })
 
-
   describe('getType', () => {
-
     const getType = dataApiClient.__get__('getType')
 
     test('stringValue', async () => {
@@ -295,42 +271,38 @@ describe('query parameter processing', () => {
       let result = getType([]) // use array for now
       expect(result).toBeUndefined()
     })
-
   })
 
-
-
   describe('formatParam', () => {
-
     const formatParam = dataApiClient.__get__('formatParam')
 
     test('stringValue', async () => {
-      let result = formatParam('param','string')
-      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' }})
+      let result = formatParam('param', 'string')
+      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' } })
     })
 
     test('booleanValue', async () => {
-      let result = formatParam('param',true)
-      expect(result).toEqual({ name: 'param', value: { booleanValue: true }})
+      let result = formatParam('param', true)
+      expect(result).toEqual({ name: 'param', value: { booleanValue: true } })
     })
 
     test('longValue', async () => {
-      let result = formatParam('param',123456789)
-      expect(result).toEqual({ name: 'param', value: { longValue: 123456789 }})
+      let result = formatParam('param', 123456789)
+      expect(result).toEqual({ name: 'param', value: { longValue: 123456789 } })
     })
 
     test('doubleValue', async () => {
-      let result = formatParam('param',1234.56789)
-      expect(result).toEqual({ name: 'param', value: { doubleValue: 1234.56789 }})
+      let result = formatParam('param', 1234.56789)
+      expect(result).toEqual({ name: 'param', value: { doubleValue: 1234.56789 } })
     })
 
     test('isNull', async () => {
-      let result = formatParam('param',null)
-      expect(result).toEqual({ name: 'param', value: { isNull: true }})
+      let result = formatParam('param', null)
+      expect(result).toEqual({ name: 'param', value: { isNull: true } })
     })
 
     test('blobValue', async () => {
-      let result = formatParam('param',Buffer.from('data'))
+      let result = formatParam('param', Buffer.from('data'))
       expect(result).toEqual({
         name: 'param',
         value: { blobValue: Buffer.from('data') }
@@ -338,7 +310,7 @@ describe('query parameter processing', () => {
     })
 
     test('supplied type', async () => {
-      let result = formatParam('param',{ stringValue: 'string' })
+      let result = formatParam('param', { stringValue: 'string' })
       expect(result).toEqual({
         name: 'param',
         value: { stringValue: 'string' }
@@ -346,48 +318,41 @@ describe('query parameter processing', () => {
     })
 
     test('invalid type (error)', async () => {
-      let result = () => formatParam('param',[]) // use array for now
+      let result = () => formatParam('param', []) // use array for now
       expect(result).toThrow(`'param' is an invalid type`)
     })
-
   })
 
   describe('getSqlParams', () => {
-
     const getSqlParams = dataApiClient.__get__('getSqlParams')
 
     test('named parameters', async () => {
       let result = getSqlParams('SELECT * FROM myTable WHERE id = :id AND test = :test')
-      expect(result).toEqual({ id: { type: 'n_ph'}, test: { type: 'n_ph'} })
+      expect(result).toEqual({ id: { type: 'n_ph' }, test: { type: 'n_ph' } })
     })
 
     test('named identifiers', async () => {
       let result = getSqlParams('SELECT ::name FROM myTable WHERE id = :id')
-      expect(result).toEqual({ id: { type: 'n_ph'}, name: { type: 'n_id'} })
+      expect(result).toEqual({ id: { type: 'n_ph' }, name: { type: 'n_id' } })
     })
-
   }) // end getSqlParams
 
-
   describe('processParams', () => {
-
     const processParams = dataApiClient.__get__('processParams')
 
     test('single param, single record', async () => {
-      let { processedParams,escapedSql } = processParams(
+      let { processedParams, escapedSql } = processParams(
         'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' } },
         [{ name: 'id', value: 1 }]
       )
       expect(escapedSql).toBe('SELECT * FROM myTable WHERE id = :id')
-      expect(processedParams).toEqual([
-        { name: 'id', value: { longValue: 1 } }
-      ])
+      expect(processedParams).toEqual([{ name: 'id', value: { longValue: 1 } }])
     })
 
     test('mulitple params, named param, single record', async () => {
-      let { processedParams,escapedSql } = processParams(
+      let { processedParams, escapedSql } = processParams(
         'pg',
         'SELECT ::columnName FROM myTable WHERE id = :id AND id2 = :id2',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' }, columnName: { type: 'n_id' } },
@@ -405,41 +370,50 @@ describe('query parameter processing', () => {
     })
 
     test('single param, multiple records', async () => {
-      let { processedParams,escapedSql } = processParams(
+      let { processedParams, escapedSql } = processParams(
         'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' } },
-        [
-          [{ name: 'id', value: 1 }],
-          [{ name: 'id', value: 2 }]
-        ]
+        [[{ name: 'id', value: 1 }], [{ name: 'id', value: 2 }]]
       )
       expect(escapedSql).toBe('SELECT * FROM myTable WHERE id = :id')
       expect(processedParams).toEqual([
-        [ { name: 'id', value: { longValue: 1 } } ],
-        [ { name: 'id', value: { longValue: 2 } } ]
+        [{ name: 'id', value: { longValue: 1 } }],
+        [{ name: 'id', value: { longValue: 2 } }]
       ])
     })
 
     test('multiple params, multiple records', async () => {
-      let { processedParams,escapedSql } = processParams(
+      let { processedParams, escapedSql } = processParams(
         'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' } },
         [
-          [{ name: 'id', value: 1 }, { name: 'id2', value: 2 } ],
-          [{ name: 'id', value: 2 }, { name: 'id2', value: 3 } ]
+          [
+            { name: 'id', value: 1 },
+            { name: 'id2', value: 2 }
+          ],
+          [
+            { name: 'id', value: 2 },
+            { name: 'id2', value: 3 }
+          ]
         ]
       )
       expect(escapedSql).toBe('SELECT * FROM myTable WHERE id = :id')
       expect(processedParams).toEqual([
-        [ { name: 'id', value: { longValue: 1 } }, { name: 'id2', value: { longValue: 2 } } ],
-        [ { name: 'id', value: { longValue: 2 } }, { name: 'id2', value: { longValue: 3 } } ]
+        [
+          { name: 'id', value: { longValue: 1 } },
+          { name: 'id2', value: { longValue: 2 } }
+        ],
+        [
+          { name: 'id', value: { longValue: 2 } },
+          { name: 'id2', value: { longValue: 3 } }
+        ]
       ])
     })
 
     test('mulitple params, named params, multiple records', async () => {
-      let { processedParams,escapedSql } = processParams(
+      let { processedParams, escapedSql } = processParams(
         'pg',
         'SELECT ::columnName FROM myTable WHERE id = :id AND id2 = :id2',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' }, columnName: { type: 'n_id' } },
@@ -470,7 +444,7 @@ describe('query parameter processing', () => {
     })
 
     test('typecasting params', async () => {
-      let { processedParams,escapedSql } = processParams(
+      let { processedParams, escapedSql } = processParams(
         'pg',
         'INSERT INTO users(id, name, meta) VALUES(:id, :name, :meta)',
         { id: { type: 'n_ph' }, name: { type: 'n_ph' }, meta: { type: 'n_ph' } },
@@ -487,15 +461,11 @@ describe('query parameter processing', () => {
         { name: 'meta', value: { stringValue: '{"extra": true}' } }
       ])
     })
-
   }) // end processParams
-
 })
 
 describe('querying', () => {
-
   describe('query', () => {
-
     const query = dataApiClient.__get__('query')
 
     let parameters = {}
@@ -518,13 +488,12 @@ describe('querying', () => {
     }
 
     test('simple query', async () => {
-
-      let result = await query(config,'SELECT * FROM table WHERE id < :id',{ id: 3 })
+      let result = await query(config, 'SELECT * FROM table WHERE id < :id', { id: 3 })
 
       expect(result).toEqual({
         records: [
-          [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
-          [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
+          [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
+          [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
         ]
       })
       expect(parameters).toEqual({
@@ -532,14 +501,12 @@ describe('querying', () => {
         resourceArn: 'resourceArn',
         database: 'db',
         sql: 'SELECT * FROM table WHERE id < :id',
-        parameters: [ { name: 'id', value: { longValue: 3 } } ]
+        parameters: [{ name: 'id', value: { longValue: 3 } }]
       })
-
     })
   }) // end query
 
   describe('formatRecords', () => {
-
     const formatRecords = dataApiClient.__get__('formatRecords')
 
     test('with columnMetadata', async () => {
@@ -569,47 +536,20 @@ describe('querying', () => {
       let { records } = require('./test/sample-query-response.json')
       let result = formatRecords(records, false)
       expect(result).toEqual([
-        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
-        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
+        [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
+        [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
       ])
     })
-  }) // end formatRecords
 
+    test('with pg lowercase typeName', async () => {
+      let { records, columnMetadata } = require('./test/sample-query-response.json')
 
-  describe('formatUpdateResults', () => {
+      columnMetadata.forEach((metadata) => {
+        metadata.typeName = metadata.typeName.toLowerCase()
+      })
 
-    const formatUpdateResults = dataApiClient.__get__('formatUpdateResults')
-
-    test('with insertIds', async () => {
-      let { updateResults } = require('./test/sample-batch-insert-response.json')
-      let result = formatUpdateResults(updateResults)
+      let result = formatRecords(records, columnMetadata, true)
       expect(result).toEqual([
-        { insertId: 316 },
-        { insertId: 317 }
-      ])
-    })
-
-    test('without insertIds', async () => {
-      let { updateResults } = require('./test/sample-batch-update-response.json')
-      let result = formatUpdateResults(updateResults)
-      expect(result).toEqual([
-        { },
-        { }
-      ])
-    })
-
-  })
-
-
-describe('formatResults', () => {
-
-  const formatResults = dataApiClient.__get__('formatResults')
-
-  test('select (hydrate)', async () => {
-    let response = require('./test/sample-query-response.json')
-    let result = formatResults(response,true,false)
-    expect(result).toEqual({
-      records: [
         {
           created: '2019-11-12 22:00:11',
           deleted: null,
@@ -626,157 +566,209 @@ describe('formatResults', () => {
           modified: '2019-11-12 22:21:36',
           name: 'Category 2'
         }
-      ]
+      ])
+    })
+  }) // end formatRecords
+
+  describe('formatUpdateResults', () => {
+    const formatUpdateResults = dataApiClient.__get__('formatUpdateResults')
+
+    test('with insertIds', async () => {
+      let { updateResults } = require('./test/sample-batch-insert-response.json')
+      let result = formatUpdateResults(updateResults)
+      expect(result).toEqual([{ insertId: 316 }, { insertId: 317 }])
+    })
+
+    test('without insertIds', async () => {
+      let { updateResults } = require('./test/sample-batch-update-response.json')
+      let result = formatUpdateResults(updateResults)
+      expect(result).toEqual([{}, {}])
     })
   })
 
-  test('select (hydrate) with date deserialization', async () => {
-    let response = require('./test/sample-query-response.json')
-    let result = formatResults(response,true,false,{deserializeDate: true})
-    expect(result).toEqual({
-      records: [
-        {
-          created: new Date('2019-11-12T22:00:11Z'),
-          deleted: null,
-          description: null,
-          id: 1,
-          modified: new Date('2019-11-12T22:15:25Z'),
-          name: 'Category 1'
-        },
-        {
-          created: new Date('2019-11-12T22:17:11Z'),
-          deleted: null,
-          description: 'Description of Category 2',
-          id: 2,
-          modified: new Date('2019-11-12T22:21:36Z'),
-          name: 'Category 2'
-        }
-      ]
+  describe('formatResults', () => {
+    const formatResults = dataApiClient.__get__('formatResults')
+
+    test('select (hydrate)', async () => {
+      let response = require('./test/sample-query-response.json')
+      let result = formatResults(response, true, false)
+      expect(result).toEqual({
+        records: [
+          {
+            created: '2019-11-12 22:00:11',
+            deleted: null,
+            description: null,
+            id: 1,
+            modified: '2019-11-12 22:15:25',
+            name: 'Category 1'
+          },
+          {
+            created: '2019-11-12 22:17:11',
+            deleted: null,
+            description: 'Description of Category 2',
+            id: 2,
+            modified: '2019-11-12 22:21:36',
+            name: 'Category 2'
+          }
+        ]
+      })
     })
-  })
 
-
-  test('select (no hydrate)', async () => {
-    let response = require('./test/sample-query-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      records: [
-        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
-        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
-      ]
+    test('select (hydrate) with date deserialization', async () => {
+      let response = require('./test/sample-query-response.json')
+      let result = formatResults(response, true, false, { deserializeDate: true })
+      expect(result).toEqual({
+        records: [
+          {
+            created: new Date('2019-11-12T22:00:11Z'),
+            deleted: null,
+            description: null,
+            id: 1,
+            modified: new Date('2019-11-12T22:15:25Z'),
+            name: 'Category 1'
+          },
+          {
+            created: new Date('2019-11-12T22:17:11Z'),
+            deleted: null,
+            description: 'Description of Category 2',
+            id: 2,
+            modified: new Date('2019-11-12T22:21:36Z'),
+            name: 'Category 2'
+          }
+        ]
+      })
     })
-  })
 
-  test('select (with metadata)', async () => {
-    let response = require('./test/sample-query-response.json')
-    let { columnMetadata } = require('./test/sample-query-response.json')
-    let result = formatResults(response,false,true)
-    expect(result).toEqual({
-      columnMetadata,
-      records: [
-        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
-        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
-      ]
+    test('select (no hydrate)', async () => {
+      let response = require('./test/sample-query-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        records: [
+          [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
+          [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
+        ]
+      })
     })
-  })
 
-  test('select (with date deserialization to UTC)', async () => {
-    let response = require('./test/sample-query-response.json')
-    let result = formatResults(response,false,false, { deserializeDate: true })
-    expect(result).toEqual({
-      records: [
-        [ 1, 'Category 1', null, new Date('2019-11-12T22:00:11.000Z'), new Date('2019-11-12T22:15:25.000Z'), null ],
-        [ 2, 'Category 2', 'Description of Category 2', new Date('2019-11-12T22:17:11.000Z'), new Date('2019-11-12T22:21:36.000Z'), null ]
-      ]
+    test('select (with metadata)', async () => {
+      let response = require('./test/sample-query-response.json')
+      let { columnMetadata } = require('./test/sample-query-response.json')
+      let result = formatResults(response, false, true)
+      expect(result).toEqual({
+        columnMetadata,
+        records: [
+          [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
+          [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
+        ]
+      })
     })
-  })
 
-  test('select (with date deserialization to local TZ)', async () => {
-    let response = require('./test/sample-query-response.json')
-    let result = formatResults(response,false,false, { deserializeDate: true, treatAsLocalDate: true })
-    expect(result).toEqual({
-      records: [
-        [ 1, 'Category 1', null, new Date('2019-11-12 22:00:11'), new Date('2019-11-12 22:15:25'), null ],
-        [ 2, 'Category 2', 'Description of Category 2', new Date('2019-11-12 22:17:11'), new Date('2019-11-12 22:21:36'), null ]
-      ]
+    test('select (with date deserialization to UTC)', async () => {
+      let response = require('./test/sample-query-response.json')
+      let result = formatResults(response, false, false, { deserializeDate: true })
+      expect(result).toEqual({
+        records: [
+          [1, 'Category 1', null, new Date('2019-11-12T22:00:11.000Z'), new Date('2019-11-12T22:15:25.000Z'), null],
+          [
+            2,
+            'Category 2',
+            'Description of Category 2',
+            new Date('2019-11-12T22:17:11.000Z'),
+            new Date('2019-11-12T22:21:36.000Z'),
+            null
+          ]
+        ]
+      })
     })
-  })
 
-  test('update', async () => {
-    let response = require('./test/sample-update-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      numberOfRecordsUpdated: 1
+    test('select (with date deserialization to local TZ)', async () => {
+      let response = require('./test/sample-query-response.json')
+      let result = formatResults(response, false, false, { deserializeDate: true, treatAsLocalDate: true })
+      expect(result).toEqual({
+        records: [
+          [1, 'Category 1', null, new Date('2019-11-12 22:00:11'), new Date('2019-11-12 22:15:25'), null],
+          [
+            2,
+            'Category 2',
+            'Description of Category 2',
+            new Date('2019-11-12 22:17:11'),
+            new Date('2019-11-12 22:21:36'),
+            null
+          ]
+        ]
+      })
     })
-  })
 
-  test('delete', async () => {
-    let response = require('./test/sample-delete-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      numberOfRecordsUpdated: 1
+    test('update', async () => {
+      let response = require('./test/sample-update-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        numberOfRecordsUpdated: 1
+      })
     })
-  })
 
-  test('insert', async () => {
-    let response = require('./test/sample-insert-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      insertId: 315,
-      numberOfRecordsUpdated: 1
+    test('delete', async () => {
+      let response = require('./test/sample-delete-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        numberOfRecordsUpdated: 1
+      })
     })
-  })
 
-  test('batch update', async () => {
-    let response = require('./test/sample-batch-update-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      updateResults: [ {}, {} ]
+    test('insert', async () => {
+      let response = require('./test/sample-insert-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        insertId: 315,
+        numberOfRecordsUpdated: 1
+      })
     })
-  })
 
-  test('batch delete', async () => {
-    let response = require('./test/sample-batch-delete-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      updateResults: [ {}, {} ]
+    test('batch update', async () => {
+      let response = require('./test/sample-batch-update-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        updateResults: [{}, {}]
+      })
     })
-  })
 
-  test('batch insert', async () => {
-    let response = require('./test/sample-batch-insert-response.json')
-    let result = formatResults(response,false,false)
-    expect(result).toEqual({
-      updateResults: [ { insertId: 316 }, { insertId: 317 } ]
+    test('batch delete', async () => {
+      let response = require('./test/sample-batch-delete-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        updateResults: [{}, {}]
+      })
     })
+
+    test('batch insert', async () => {
+      let response = require('./test/sample-batch-insert-response.json')
+      let result = formatResults(response, false, false)
+      expect(result).toEqual({
+        updateResults: [{ insertId: 316 }, { insertId: 317 }]
+      })
+    })
+
+    // Formats the results of a query response
+    // const formatResults = (
+    //   { // destructure results
+    //     columnMetadata, // ONLY when hydrate or includeResultMetadata is true
+    //     numberOfRecordsUpdated, // ONLY for executeStatement method
+    //     records, // ONLY for executeStatement method
+    //     generatedFields, // ONLY for INSERTS
+    //     updateResults // ONLY on batchExecuteStatement
+    //   },
+    //   hydrate,
+    //   includeMeta
+    // ) =>
+    //   Object.assign(
+    //     includeMeta ? { columnMetadata } : {},
+    //     numberOfRecordsUpdated !== undefined && !records ? { numberOfRecordsUpdated } : {},
+    //     records ? {
+    //       records: formatRecords(records, hydrate ? columnMetadata : false)
+    //     } : {},
+    //     updateResults ? { updateResults: formatUpdateResults(updateResults) } : {},
+    //     generatedFields && generatedFields.length > 0 ?
+    //       { insertId: generatedFields[0].longValue } : {}
+    //   )
   })
-
-
-  // Formats the results of a query response
-  // const formatResults = (
-  //   { // destructure results
-  //     columnMetadata, // ONLY when hydrate or includeResultMetadata is true
-  //     numberOfRecordsUpdated, // ONLY for executeStatement method
-  //     records, // ONLY for executeStatement method
-  //     generatedFields, // ONLY for INSERTS
-  //     updateResults // ONLY on batchExecuteStatement
-  //   },
-  //   hydrate,
-  //   includeMeta
-  // ) =>
-  //   Object.assign(
-  //     includeMeta ? { columnMetadata } : {},
-  //     numberOfRecordsUpdated !== undefined && !records ? { numberOfRecordsUpdated } : {},
-  //     records ? {
-  //       records: formatRecords(records, hydrate ? columnMetadata : false)
-  //     } : {},
-  //     updateResults ? { updateResults: formatUpdateResults(updateResults) } : {},
-  //     generatedFields && generatedFields.length > 0 ?
-  //       { insertId: generatedFields[0].longValue } : {}
-  //   )
-
-
-})
-
-
 })

--- a/index.test.js
+++ b/index.test.js
@@ -807,4 +807,4 @@ describe('formatResults', () => {
 })
 
 
-})
+}) 

--- a/index.test.js
+++ b/index.test.js
@@ -807,4 +807,4 @@ describe('formatResults', () => {
 })
 
 
-}) 
+})

--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,7 @@ const dataApiClient = rewire('./index')
 // })
 
 describe('utility', () => {
+
   test('error', async () => {
     const error = dataApiClient.__get__('error')
     let err = () => error('test error')
@@ -20,25 +21,29 @@ describe('utility', () => {
 
   test('omit', async () => {
     const omit = dataApiClient.__get__('omit')
-    let result = omit({ a: 1, b: 2, c: 3 }, ['c'])
+    let result = omit({ a: 1, b: 2, c: 3},['c'])
     expect(result).toEqual({ a: 1, b: 2 })
   })
 
   test('pick', async () => {
     const pick = dataApiClient.__get__('pick')
-    let result = pick({ a: 1, b: 2, c: 3 }, ['a', 'c'])
+    let result = pick({ a: 1, b: 2, c: 3},['a','c'])
     expect(result).toEqual({ a: 1, c: 3 })
   })
 
   test('flatten', async () => {
     const flatten = dataApiClient.__get__('flatten')
-    let result = flatten([[1, 2, 3], 4, [5, 6], 7, 8])
-    expect(result).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    let result = flatten([[1,2,3],4,[5,6],7,8])
+    expect(result).toEqual([1,2,3,4,5,6,7,8])
   })
+
 }) // end utility
 
+
 describe('query parsing', () => {
+
   describe('parseSQL', () => {
+
     const parseSQL = dataApiClient.__get__('parseSQL')
 
     test('string', async () => {
@@ -57,27 +62,29 @@ describe('query parsing', () => {
     })
   }) // end parseSQL
 
+
   describe('parseParams', () => {
+
     const parseParams = dataApiClient.__get__('parseParams')
 
     test('array', async () => {
-      let result = parseParams(['query', [1, 2]])
-      expect(result).toEqual([1, 2])
+      let result = parseParams(['query',[1,2]])
+      expect(result).toEqual([1,2])
     })
 
     test('object', async () => {
-      let result = parseParams(['query', { a: 1, b: 2 }])
-      expect(result).toEqual([{ a: 1, b: 2 }])
+      let result = parseParams(['query', { a: 1, b: 2}])
+      expect(result).toEqual([{ a:1, b:2 }])
     })
 
     test('array (in object)', async () => {
-      let result = parseParams([{ parameters: [1, 2, 3] }])
-      expect(result).toEqual([1, 2, 3])
+      let result = parseParams([{ parameters: [1,2,3] }])
+      expect(result).toEqual([1,2,3])
     })
 
     test('object (in object)', async () => {
-      let result = parseParams([{ parameters: { a: 1, b: 2 } }])
-      expect(result).toEqual([{ a: 1, b: 2 }])
+      let result = parseParams([{ parameters: { a: 1, b: 2} }])
+      expect(result).toEqual([{ a:1, b:2 }])
     })
 
     test('no params (empty array)', async () => {
@@ -86,12 +93,12 @@ describe('query parsing', () => {
     })
 
     test('no params in object (empty array)', async () => {
-      let result = parseParams([{}])
+      let result = parseParams([{ }])
       expect(result).toEqual([])
     })
 
     test('invalid type (error)', async () => {
-      let result = () => parseParams(['query', 'string'])
+      let result = () => parseParams(['query','string'])
       expect(result).toThrow('Parameters must be an object or array')
     })
 
@@ -99,21 +106,26 @@ describe('query parsing', () => {
       let result = () => parseParams([{ parameters: 'string' }])
       expect(result).toThrow(`'parameters' must be an object or array`)
     })
+
   }) // end parse params
+
 }) // end query parsing
 
+
 describe('query configuration parsing', () => {
+
   test('mergeConfig', async () => {
     const mergeConfig = dataApiClient.__get__('mergeConfig')
-    let result = mergeConfig({ secretArn: 'secretArn', resourceArn: 'resourceArn' }, { database: 'db' })
-    expect(result).toEqual({ secretArn: 'secretArn', resourceArn: 'resourceArn', database: 'db' })
+    let result = mergeConfig({ secretArn:'secretArn',resourceArn:'resourceArn' }, { database: 'db' })
+    expect(result).toEqual({ secretArn:'secretArn',resourceArn:'resourceArn', database: 'db' })
   })
 
   describe('parseDatabase', () => {
+
     const parseDatabase = dataApiClient.__get__('parseDatabase')
 
     test('from config w/ transaction', async () => {
-      let result = parseDatabase({ database: 'db', transactionId: 'txid' })
+      let result = parseDatabase({ database: 'db', transactionId: 'txid'})
       expect(result).toBe('db')
     })
 
@@ -136,45 +148,53 @@ describe('query configuration parsing', () => {
       let result = parseDatabase({}, [{}])
       expect(result).toBe.undefined
     })
+
   }) // end parseDatabase
 
   describe('parseHydrate', () => {
+
     const parseHydrate = dataApiClient.__get__('parseHydrate')
 
     test('parseHydrate - from args', async () => {
-      let result = parseHydrate({ hydrateColumnNames: true }, [{ hydrateColumnNames: false }])
+      let result = parseHydrate({ hydrateColumnNames: true },[{ hydrateColumnNames: false }])
       expect(result).toBe(false)
     })
 
     test('parseHydrate - from config', async () => {
-      let result = parseHydrate({ hydrateColumnNames: true }, [{}])
+      let result = parseHydrate({ hydrateColumnNames: true },[{ }])
       expect(result).toBe(true)
     })
 
     test('parseHydrate - from args, not boolean (error)', async () => {
-      let result = () => parseHydrate({ hydrateColumnNames: true }, [{ hydrateColumnNames: 'false' }])
+      let result = () => parseHydrate({ hydrateColumnNames: true },[{ hydrateColumnNames: 'false' }])
       expect(result).toThrow(`'hydrateColumnNames' must be a boolean.`)
     })
+
   })
 
+
   describe('prepareParams', () => {
+
     const prepareParams = dataApiClient.__get__('prepareParams')
 
     test('prepareParams - omit specific args, merge others', async () => {
-      let result = prepareParams({ secretArn: 'secretArn', resourceArn: 'resourceArn' }, [
-        { hydrateColumnNames: true, parameters: [1, 2, 3], test: true }
-      ])
+      let result = prepareParams({ secretArn:'secretArn',resourceArn:'resourceArn' },
+        [{ hydrateColumnNames: true, parameters: [1,2,3], test: true }])
       expect(result).toEqual({ secretArn: 'secretArn', resourceArn: 'resourceArn', test: true })
     })
 
     test('prepareParams - no args', async () => {
-      let result = prepareParams({ secretArn: 'secretArn', resourceArn: 'resourceArn' }, [])
+      let result = prepareParams({ secretArn:'secretArn',resourceArn:'resourceArn' },[])
       expect(result).toEqual({ secretArn: 'secretArn', resourceArn: 'resourceArn' })
     })
+
   }) // end prepareParams
+
 }) // end query config parsing
 
+
 describe('query parameter processing', () => {
+
   test('splitParams', async () => {
     const splitParams = dataApiClient.__get__('splitParams')
     let result = splitParams({ param1: 'p1', param2: 'p2' })
@@ -189,7 +209,7 @@ describe('query parameter processing', () => {
     let result = normalizeParams([
       { name: 'param1', value: 'p1' },
       { param2: 'p2' },
-      [{ name: 'param3', value: 'p3' }, { param4: 'p4' }],
+      [ { name: 'param3', value: 'p3' }, { param4: 'p4'} ],
       { name: 'param5', value: 'p5', param6: 'p6' }
     ])
     expect(result).toEqual([
@@ -206,35 +226,39 @@ describe('query parameter processing', () => {
   })
 
   describe('formatType', () => {
+
     const formatType = dataApiClient.__get__('formatType')
 
     test('stringValue', async () => {
-      let result = formatType('param', 'string val', 'stringValue')
-      expect(result).toEqual({ name: 'param', value: { stringValue: 'string val' } })
+      let result = formatType('param','string val','stringValue')
+      expect(result).toEqual({ name: 'param', value: { stringValue: 'string val' }})
     })
 
     test('booleanValue', async () => {
-      let result = formatType('param', true, 'booleanValue')
-      expect(result).toEqual({ name: 'param', value: { booleanValue: true } })
+      let result = formatType('param',true,'booleanValue')
+      expect(result).toEqual({ name: 'param', value: { booleanValue: true }})
     })
 
     test('longValue', async () => {
-      let result = formatType('param', 1234567890, 'longValue')
-      expect(result).toEqual({ name: 'param', value: { longValue: 1234567890 } })
+      let result = formatType('param',1234567890,'longValue')
+      expect(result).toEqual({ name: 'param', value: { longValue: 1234567890 }})
     })
 
     test('existing type', async () => {
-      let result = formatType('param', { stringValue: 'string' }, null)
-      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' } })
+      let result = formatType('param',{ stringValue: 'string' },null)
+      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' }})
     })
 
     test('undefined (error)', async () => {
-      let result = () => formatType('param', 'invalid type', undefined)
+      let result = () => formatType('param','invalid type',undefined)
       expect(result).toThrow(`'param' is an invalid type`)
     })
+
   })
 
+
   describe('getType', () => {
+
     const getType = dataApiClient.__get__('getType')
 
     test('stringValue', async () => {
@@ -271,38 +295,42 @@ describe('query parameter processing', () => {
       let result = getType([]) // use array for now
       expect(result).toBeUndefined()
     })
+
   })
 
+
+
   describe('formatParam', () => {
+
     const formatParam = dataApiClient.__get__('formatParam')
 
     test('stringValue', async () => {
-      let result = formatParam('param', 'string')
-      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' } })
+      let result = formatParam('param','string')
+      expect(result).toEqual({ name: 'param', value: { stringValue: 'string' }})
     })
 
     test('booleanValue', async () => {
-      let result = formatParam('param', true)
-      expect(result).toEqual({ name: 'param', value: { booleanValue: true } })
+      let result = formatParam('param',true)
+      expect(result).toEqual({ name: 'param', value: { booleanValue: true }})
     })
 
     test('longValue', async () => {
-      let result = formatParam('param', 123456789)
-      expect(result).toEqual({ name: 'param', value: { longValue: 123456789 } })
+      let result = formatParam('param',123456789)
+      expect(result).toEqual({ name: 'param', value: { longValue: 123456789 }})
     })
 
     test('doubleValue', async () => {
-      let result = formatParam('param', 1234.56789)
-      expect(result).toEqual({ name: 'param', value: { doubleValue: 1234.56789 } })
+      let result = formatParam('param',1234.56789)
+      expect(result).toEqual({ name: 'param', value: { doubleValue: 1234.56789 }})
     })
 
     test('isNull', async () => {
-      let result = formatParam('param', null)
-      expect(result).toEqual({ name: 'param', value: { isNull: true } })
+      let result = formatParam('param',null)
+      expect(result).toEqual({ name: 'param', value: { isNull: true }})
     })
 
     test('blobValue', async () => {
-      let result = formatParam('param', Buffer.from('data'))
+      let result = formatParam('param',Buffer.from('data'))
       expect(result).toEqual({
         name: 'param',
         value: { blobValue: Buffer.from('data') }
@@ -310,7 +338,7 @@ describe('query parameter processing', () => {
     })
 
     test('supplied type', async () => {
-      let result = formatParam('param', { stringValue: 'string' })
+      let result = formatParam('param',{ stringValue: 'string' })
       expect(result).toEqual({
         name: 'param',
         value: { stringValue: 'string' }
@@ -318,41 +346,48 @@ describe('query parameter processing', () => {
     })
 
     test('invalid type (error)', async () => {
-      let result = () => formatParam('param', []) // use array for now
+      let result = () => formatParam('param',[]) // use array for now
       expect(result).toThrow(`'param' is an invalid type`)
     })
+
   })
 
   describe('getSqlParams', () => {
+
     const getSqlParams = dataApiClient.__get__('getSqlParams')
 
     test('named parameters', async () => {
       let result = getSqlParams('SELECT * FROM myTable WHERE id = :id AND test = :test')
-      expect(result).toEqual({ id: { type: 'n_ph' }, test: { type: 'n_ph' } })
+      expect(result).toEqual({ id: { type: 'n_ph'}, test: { type: 'n_ph'} })
     })
 
     test('named identifiers', async () => {
       let result = getSqlParams('SELECT ::name FROM myTable WHERE id = :id')
-      expect(result).toEqual({ id: { type: 'n_ph' }, name: { type: 'n_id' } })
+      expect(result).toEqual({ id: { type: 'n_ph'}, name: { type: 'n_id'} })
     })
+
   }) // end getSqlParams
 
+
   describe('processParams', () => {
+
     const processParams = dataApiClient.__get__('processParams')
 
     test('single param, single record', async () => {
-      let { processedParams, escapedSql } = processParams(
+      let { processedParams,escapedSql } = processParams(
         'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' } },
         [{ name: 'id', value: 1 }]
       )
       expect(escapedSql).toBe('SELECT * FROM myTable WHERE id = :id')
-      expect(processedParams).toEqual([{ name: 'id', value: { longValue: 1 } }])
+      expect(processedParams).toEqual([
+        { name: 'id', value: { longValue: 1 } }
+      ])
     })
 
     test('mulitple params, named param, single record', async () => {
-      let { processedParams, escapedSql } = processParams(
+      let { processedParams,escapedSql } = processParams(
         'pg',
         'SELECT ::columnName FROM myTable WHERE id = :id AND id2 = :id2',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' }, columnName: { type: 'n_id' } },
@@ -370,50 +405,41 @@ describe('query parameter processing', () => {
     })
 
     test('single param, multiple records', async () => {
-      let { processedParams, escapedSql } = processParams(
+      let { processedParams,escapedSql } = processParams(
         'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' } },
-        [[{ name: 'id', value: 1 }], [{ name: 'id', value: 2 }]]
+        [
+          [{ name: 'id', value: 1 }],
+          [{ name: 'id', value: 2 }]
+        ]
       )
       expect(escapedSql).toBe('SELECT * FROM myTable WHERE id = :id')
       expect(processedParams).toEqual([
-        [{ name: 'id', value: { longValue: 1 } }],
-        [{ name: 'id', value: { longValue: 2 } }]
+        [ { name: 'id', value: { longValue: 1 } } ],
+        [ { name: 'id', value: { longValue: 2 } } ]
       ])
     })
 
     test('multiple params, multiple records', async () => {
-      let { processedParams, escapedSql } = processParams(
+      let { processedParams,escapedSql } = processParams(
         'pg',
         'SELECT * FROM myTable WHERE id = :id',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' } },
         [
-          [
-            { name: 'id', value: 1 },
-            { name: 'id2', value: 2 }
-          ],
-          [
-            { name: 'id', value: 2 },
-            { name: 'id2', value: 3 }
-          ]
+          [{ name: 'id', value: 1 }, { name: 'id2', value: 2 } ],
+          [{ name: 'id', value: 2 }, { name: 'id2', value: 3 } ]
         ]
       )
       expect(escapedSql).toBe('SELECT * FROM myTable WHERE id = :id')
       expect(processedParams).toEqual([
-        [
-          { name: 'id', value: { longValue: 1 } },
-          { name: 'id2', value: { longValue: 2 } }
-        ],
-        [
-          { name: 'id', value: { longValue: 2 } },
-          { name: 'id2', value: { longValue: 3 } }
-        ]
+        [ { name: 'id', value: { longValue: 1 } }, { name: 'id2', value: { longValue: 2 } } ],
+        [ { name: 'id', value: { longValue: 2 } }, { name: 'id2', value: { longValue: 3 } } ]
       ])
     })
 
     test('mulitple params, named params, multiple records', async () => {
-      let { processedParams, escapedSql } = processParams(
+      let { processedParams,escapedSql } = processParams(
         'pg',
         'SELECT ::columnName FROM myTable WHERE id = :id AND id2 = :id2',
         { id: { type: 'n_ph' }, id2: { type: 'n_ph' }, columnName: { type: 'n_id' } },
@@ -444,7 +470,7 @@ describe('query parameter processing', () => {
     })
 
     test('typecasting params', async () => {
-      let { processedParams, escapedSql } = processParams(
+      let { processedParams,escapedSql } = processParams(
         'pg',
         'INSERT INTO users(id, name, meta) VALUES(:id, :name, :meta)',
         { id: { type: 'n_ph' }, name: { type: 'n_ph' }, meta: { type: 'n_ph' } },
@@ -461,11 +487,15 @@ describe('query parameter processing', () => {
         { name: 'meta', value: { stringValue: '{"extra": true}' } }
       ])
     })
+
   }) // end processParams
+
 })
 
 describe('querying', () => {
+
   describe('query', () => {
+
     const query = dataApiClient.__get__('query')
 
     let parameters = {}
@@ -488,12 +518,13 @@ describe('querying', () => {
     }
 
     test('simple query', async () => {
-      let result = await query(config, 'SELECT * FROM table WHERE id < :id', { id: 3 })
+
+      let result = await query(config,'SELECT * FROM table WHERE id < :id',{ id: 3 })
 
       expect(result).toEqual({
         records: [
-          [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
-          [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
+          [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
+          [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
         ]
       })
       expect(parameters).toEqual({
@@ -501,12 +532,14 @@ describe('querying', () => {
         resourceArn: 'resourceArn',
         database: 'db',
         sql: 'SELECT * FROM table WHERE id < :id',
-        parameters: [{ name: 'id', value: { longValue: 3 } }]
+        parameters: [ { name: 'id', value: { longValue: 3 } } ]
       })
+
     })
   }) // end query
 
   describe('formatRecords', () => {
+
     const formatRecords = dataApiClient.__get__('formatRecords')
 
     test('with columnMetadata', async () => {
@@ -536,11 +569,11 @@ describe('querying', () => {
       let { records } = require('./test/sample-query-response.json')
       let result = formatRecords(records, false)
       expect(result).toEqual([
-        [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
-        [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
+        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
+        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
       ])
     })
-
+    
     test('with pg lowercase typeName', async () => {
       let { records, columnMetadata } = require('./test/sample-query-response.json')
 
@@ -570,205 +603,208 @@ describe('querying', () => {
     })
   }) // end formatRecords
 
+
   describe('formatUpdateResults', () => {
+
     const formatUpdateResults = dataApiClient.__get__('formatUpdateResults')
 
     test('with insertIds', async () => {
       let { updateResults } = require('./test/sample-batch-insert-response.json')
       let result = formatUpdateResults(updateResults)
-      expect(result).toEqual([{ insertId: 316 }, { insertId: 317 }])
+      expect(result).toEqual([
+        { insertId: 316 },
+        { insertId: 317 }
+      ])
     })
 
     test('without insertIds', async () => {
       let { updateResults } = require('./test/sample-batch-update-response.json')
       let result = formatUpdateResults(updateResults)
-      expect(result).toEqual([{}, {}])
+      expect(result).toEqual([
+        { },
+        { }
+      ])
+    })
+
+  })
+
+
+describe('formatResults', () => {
+
+  const formatResults = dataApiClient.__get__('formatResults')
+
+  test('select (hydrate)', async () => {
+    let response = require('./test/sample-query-response.json')
+    let result = formatResults(response,true,false)
+    expect(result).toEqual({
+      records: [
+        {
+          created: '2019-11-12 22:00:11',
+          deleted: null,
+          description: null,
+          id: 1,
+          modified: '2019-11-12 22:15:25',
+          name: 'Category 1'
+        },
+        {
+          created: '2019-11-12 22:17:11',
+          deleted: null,
+          description: 'Description of Category 2',
+          id: 2,
+          modified: '2019-11-12 22:21:36',
+          name: 'Category 2'
+        }
+      ]
     })
   })
 
-  describe('formatResults', () => {
-    const formatResults = dataApiClient.__get__('formatResults')
-
-    test('select (hydrate)', async () => {
-      let response = require('./test/sample-query-response.json')
-      let result = formatResults(response, true, false)
-      expect(result).toEqual({
-        records: [
-          {
-            created: '2019-11-12 22:00:11',
-            deleted: null,
-            description: null,
-            id: 1,
-            modified: '2019-11-12 22:15:25',
-            name: 'Category 1'
-          },
-          {
-            created: '2019-11-12 22:17:11',
-            deleted: null,
-            description: 'Description of Category 2',
-            id: 2,
-            modified: '2019-11-12 22:21:36',
-            name: 'Category 2'
-          }
-        ]
-      })
+  test('select (hydrate) with date deserialization', async () => {
+    let response = require('./test/sample-query-response.json')
+    let result = formatResults(response,true,false,{deserializeDate: true})
+    expect(result).toEqual({
+      records: [
+        {
+          created: new Date('2019-11-12T22:00:11Z'),
+          deleted: null,
+          description: null,
+          id: 1,
+          modified: new Date('2019-11-12T22:15:25Z'),
+          name: 'Category 1'
+        },
+        {
+          created: new Date('2019-11-12T22:17:11Z'),
+          deleted: null,
+          description: 'Description of Category 2',
+          id: 2,
+          modified: new Date('2019-11-12T22:21:36Z'),
+          name: 'Category 2'
+        }
+      ]
     })
-
-    test('select (hydrate) with date deserialization', async () => {
-      let response = require('./test/sample-query-response.json')
-      let result = formatResults(response, true, false, { deserializeDate: true })
-      expect(result).toEqual({
-        records: [
-          {
-            created: new Date('2019-11-12T22:00:11Z'),
-            deleted: null,
-            description: null,
-            id: 1,
-            modified: new Date('2019-11-12T22:15:25Z'),
-            name: 'Category 1'
-          },
-          {
-            created: new Date('2019-11-12T22:17:11Z'),
-            deleted: null,
-            description: 'Description of Category 2',
-            id: 2,
-            modified: new Date('2019-11-12T22:21:36Z'),
-            name: 'Category 2'
-          }
-        ]
-      })
-    })
-
-    test('select (no hydrate)', async () => {
-      let response = require('./test/sample-query-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        records: [
-          [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
-          [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
-        ]
-      })
-    })
-
-    test('select (with metadata)', async () => {
-      let response = require('./test/sample-query-response.json')
-      let { columnMetadata } = require('./test/sample-query-response.json')
-      let result = formatResults(response, false, true)
-      expect(result).toEqual({
-        columnMetadata,
-        records: [
-          [1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null],
-          [2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null]
-        ]
-      })
-    })
-
-    test('select (with date deserialization to UTC)', async () => {
-      let response = require('./test/sample-query-response.json')
-      let result = formatResults(response, false, false, { deserializeDate: true })
-      expect(result).toEqual({
-        records: [
-          [1, 'Category 1', null, new Date('2019-11-12T22:00:11.000Z'), new Date('2019-11-12T22:15:25.000Z'), null],
-          [
-            2,
-            'Category 2',
-            'Description of Category 2',
-            new Date('2019-11-12T22:17:11.000Z'),
-            new Date('2019-11-12T22:21:36.000Z'),
-            null
-          ]
-        ]
-      })
-    })
-
-    test('select (with date deserialization to local TZ)', async () => {
-      let response = require('./test/sample-query-response.json')
-      let result = formatResults(response, false, false, { deserializeDate: true, treatAsLocalDate: true })
-      expect(result).toEqual({
-        records: [
-          [1, 'Category 1', null, new Date('2019-11-12 22:00:11'), new Date('2019-11-12 22:15:25'), null],
-          [
-            2,
-            'Category 2',
-            'Description of Category 2',
-            new Date('2019-11-12 22:17:11'),
-            new Date('2019-11-12 22:21:36'),
-            null
-          ]
-        ]
-      })
-    })
-
-    test('update', async () => {
-      let response = require('./test/sample-update-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        numberOfRecordsUpdated: 1
-      })
-    })
-
-    test('delete', async () => {
-      let response = require('./test/sample-delete-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        numberOfRecordsUpdated: 1
-      })
-    })
-
-    test('insert', async () => {
-      let response = require('./test/sample-insert-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        insertId: 315,
-        numberOfRecordsUpdated: 1
-      })
-    })
-
-    test('batch update', async () => {
-      let response = require('./test/sample-batch-update-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        updateResults: [{}, {}]
-      })
-    })
-
-    test('batch delete', async () => {
-      let response = require('./test/sample-batch-delete-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        updateResults: [{}, {}]
-      })
-    })
-
-    test('batch insert', async () => {
-      let response = require('./test/sample-batch-insert-response.json')
-      let result = formatResults(response, false, false)
-      expect(result).toEqual({
-        updateResults: [{ insertId: 316 }, { insertId: 317 }]
-      })
-    })
-
-    // Formats the results of a query response
-    // const formatResults = (
-    //   { // destructure results
-    //     columnMetadata, // ONLY when hydrate or includeResultMetadata is true
-    //     numberOfRecordsUpdated, // ONLY for executeStatement method
-    //     records, // ONLY for executeStatement method
-    //     generatedFields, // ONLY for INSERTS
-    //     updateResults // ONLY on batchExecuteStatement
-    //   },
-    //   hydrate,
-    //   includeMeta
-    // ) =>
-    //   Object.assign(
-    //     includeMeta ? { columnMetadata } : {},
-    //     numberOfRecordsUpdated !== undefined && !records ? { numberOfRecordsUpdated } : {},
-    //     records ? {
-    //       records: formatRecords(records, hydrate ? columnMetadata : false)
-    //     } : {},
-    //     updateResults ? { updateResults: formatUpdateResults(updateResults) } : {},
-    //     generatedFields && generatedFields.length > 0 ?
-    //       { insertId: generatedFields[0].longValue } : {}
-    //   )
   })
+
+
+  test('select (no hydrate)', async () => {
+    let response = require('./test/sample-query-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      records: [
+        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
+        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
+      ]
+    })
+  })
+
+  test('select (with metadata)', async () => {
+    let response = require('./test/sample-query-response.json')
+    let { columnMetadata } = require('./test/sample-query-response.json')
+    let result = formatResults(response,false,true)
+    expect(result).toEqual({
+      columnMetadata,
+      records: [
+        [ 1, 'Category 1', null, '2019-11-12 22:00:11', '2019-11-12 22:15:25', null ],
+        [ 2, 'Category 2', 'Description of Category 2', '2019-11-12 22:17:11', '2019-11-12 22:21:36', null ]
+      ]
+    })
+  })
+
+  test('select (with date deserialization to UTC)', async () => {
+    let response = require('./test/sample-query-response.json')
+    let result = formatResults(response,false,false, { deserializeDate: true })
+    expect(result).toEqual({
+      records: [
+        [ 1, 'Category 1', null, new Date('2019-11-12T22:00:11.000Z'), new Date('2019-11-12T22:15:25.000Z'), null ],
+        [ 2, 'Category 2', 'Description of Category 2', new Date('2019-11-12T22:17:11.000Z'), new Date('2019-11-12T22:21:36.000Z'), null ]
+      ]
+    })
+  })
+
+  test('select (with date deserialization to local TZ)', async () => {
+    let response = require('./test/sample-query-response.json')
+    let result = formatResults(response,false,false, { deserializeDate: true, treatAsLocalDate: true })
+    expect(result).toEqual({
+      records: [
+        [ 1, 'Category 1', null, new Date('2019-11-12 22:00:11'), new Date('2019-11-12 22:15:25'), null ],
+        [ 2, 'Category 2', 'Description of Category 2', new Date('2019-11-12 22:17:11'), new Date('2019-11-12 22:21:36'), null ]
+      ]
+    })
+  })
+
+  test('update', async () => {
+    let response = require('./test/sample-update-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      numberOfRecordsUpdated: 1
+    })
+  })
+
+  test('delete', async () => {
+    let response = require('./test/sample-delete-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      numberOfRecordsUpdated: 1
+    })
+  })
+
+  test('insert', async () => {
+    let response = require('./test/sample-insert-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      insertId: 315,
+      numberOfRecordsUpdated: 1
+    })
+  })
+
+  test('batch update', async () => {
+    let response = require('./test/sample-batch-update-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      updateResults: [ {}, {} ]
+    })
+  })
+
+  test('batch delete', async () => {
+    let response = require('./test/sample-batch-delete-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      updateResults: [ {}, {} ]
+    })
+  })
+
+  test('batch insert', async () => {
+    let response = require('./test/sample-batch-insert-response.json')
+    let result = formatResults(response,false,false)
+    expect(result).toEqual({
+      updateResults: [ { insertId: 316 }, { insertId: 317 } ]
+    })
+  })
+
+
+  // Formats the results of a query response
+  // const formatResults = (
+  //   { // destructure results
+  //     columnMetadata, // ONLY when hydrate or includeResultMetadata is true
+  //     numberOfRecordsUpdated, // ONLY for executeStatement method
+  //     records, // ONLY for executeStatement method
+  //     generatedFields, // ONLY for INSERTS
+  //     updateResults // ONLY on batchExecuteStatement
+  //   },
+  //   hydrate,
+  //   includeMeta
+  // ) =>
+  //   Object.assign(
+  //     includeMeta ? { columnMetadata } : {},
+  //     numberOfRecordsUpdated !== undefined && !records ? { numberOfRecordsUpdated } : {},
+  //     records ? {
+  //       records: formatRecords(records, hydrate ? columnMetadata : false)
+  //     } : {},
+  //     updateResults ? { updateResults: formatUpdateResults(updateResults) } : {},
+  //     generatedFields && generatedFields.length > 0 ?
+  //       { insertId: generatedFields[0].longValue } : {}
+  //   )
+
+
+})
+
+
 })


### PR DESCRIPTION
aurora serverless with postgresql returns typeName as lowercase. because of this, the function formatRecordValue does not function properly for pg responses.

to fix, I cast the typeName to uppercase at the start of the function, storing it in a new const standardizedTypeName.
added a test case to cover this issue.

Linking to pull #117 