### PR TITLE
ci: serialize Integration Tests against shared Aurora cluster

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,15 @@ on:
     branches: [main, v2.0.0]
   workflow_dispatch:
 
+# Serialize all runs against the shared Aurora cluster. Without this,
+# concurrent PRs and main pushes race on table create/drop in their
+# beforeAll/afterAll hooks, producing spurious "Table doesn't exist"
+# failures. cancel-in-progress: false so we never interrupt a run
+# mid-afterAll and leave the cluster in a half-cleaned state.
+concurrency:
+  group: integration-tests
+  cancel-in-progress: false
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add a workflow-level `concurrency:` block to `integration-tests.yml` so runs queue instead of racing
- Group key is a single global string (`integration-tests`) so PR and main-push runs share the queue
- `cancel-in-progress: false` to avoid interrupting an in-flight run's `afterAll` teardown

## Motivation

The integration test workflow runs against a single shared Aurora cluster (one set of `MYSQL_RESOURCE_ARN` / `POSTGRES_RESOURCE_ARN` secrets). Each test file uses `beforeAll` to create its own extended tables (e.g. `blob_tests`, `type_tests`, `array_tests`, `range_tests`) and `afterAll` to drop them. When two runs overlap, one run's drop in `afterAll` removes tables out from under another run's `beforeEach` / test bodies, producing failures like:

```
Table '<db>.blob_tests' doesn't exist; Error code: 1146; SQLState: 42S02
ERROR: relation "type_tests" does not exist; SQLState: 42P01
```

This was the root cause of all the recent Dependabot PR CI failures (#169, #170) — re-running them alone made them pass.

## Test plan

- [ ] Workflow YAML is valid (GitHub renders the new job summary)
- [ ] This PR's own CI run completes successfully (proves the syntax is accepted)
- [ ] Open a second PR (or trigger via `workflow_dispatch`) while this one is running and confirm the second run queues instead of starting in parallel — observable in the Actions UI as "Queued" status